### PR TITLE
Switch to openjdk8 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 stages:
   - name: test


### PR DESCRIPTION
Many PRs got error since oraclejdk8 is no longer available in Travis.
E.g. https://travis-ci.com/tanishiking/scalaunfmt/jobs/223263192#L167

This PR swicthes JDK to openjdk8
