### PR TITLE
Show right version of scalaunfmt in help message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val scoptV = "3.7.1"
 val similarityV = "1.2.1"
 
 lazy val scalaunfmt = (project in file(".")).
+  enablePlugins(BuildInfoPlugin).
   settings(
     name := "scalaunfmt",
     organization := "com.github.tanishiking",
@@ -29,6 +30,9 @@ lazy val scalaunfmt = (project in file(".")).
       "-opt:l:inline",
       "-opt-inline-from"
     ),
+
+    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoPackage := "com.github.tanishiking.scalaunfmt",
 
     homepage := Some(url("https://github.com/tanishiking/scalaunfmt")),
     licenses := List("MIT License" -> url("http://www.opensource.org/licenses/mit-license.php")),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.3.2")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/src/main/scala/com/github/tanishiking/scalaunfmt/cli/CliArgParser.scala
+++ b/src/main/scala/com/github/tanishiking/scalaunfmt/cli/CliArgParser.scala
@@ -1,4 +1,5 @@
-package com.github.tanishiking.scalaunfmt.cli
+package com.github.tanishiking.scalaunfmt
+package cli
 
 import java.io.File
 
@@ -8,7 +9,7 @@ object CliArgParser {
   val scoptParser: OptionParser[CliOptions] =
     new scopt.OptionParser[CliOptions]("scalaunfmt") {
 
-      head("scalaunfmt", "0.0.3")
+      head("scalaunfmt", BuildInfo.version)
       arg[File]("<file>...")
         .optional()
         .unbounded()


### PR DESCRIPTION
Though the latest version of scalaunfmt is 0.0.4, we were showing its version as 0.0.3 in help message.
This PR fixes it by introducing sbt-buildinfo.